### PR TITLE
MB-48564 - Add new instance types to AWS Sync Gateway CFTs

### DIFF
--- a/aws/CouchbaseServerAndSyncGateway/couchbase-amzn-lnx2.template
+++ b/aws/CouchbaseServerAndSyncGateway/couchbase-amzn-lnx2.template
@@ -192,6 +192,9 @@
             "AllowedValues": [
                 "c5n.xlarge",
                 "t3.medium",
+                "t3.large",
+                "t3.xlarge",
+                "t3.2xlarge",
                 "m4.large",
                 "m4.xlarge",
                 "m4.2xlarge",
@@ -208,6 +211,11 @@
                 "c5.4xlarge",
                 "r5.large",
                 "r5.xlarge",
+                "r5.2xlarge",
+                "r5.4xlarge",
+                "r5d.xlarge",
+                "r5d.2xlarge",
+                "r5d.4xlarge",
                 "r4.large",
                 "r4.xlarge",
                 "m5a.large",
@@ -216,7 +224,9 @@
                 "r5a.large",
                 "r5a.xlarge",
                 "i3.large",
-                "i3.xlarge"
+                "i3.xlarge",
+                "c5n.2xlarge",
+                "c5n.4xlarge"
             ]
         },
         "Username": {

--- a/aws/CouchbaseSyncGateway/couchbase-amzn-lnx2.template
+++ b/aws/CouchbaseSyncGateway/couchbase-amzn-lnx2.template
@@ -102,6 +102,9 @@
             "AllowedValues": [
                 "c5n.xlarge",
                 "t3.medium",
+                "t3.large",
+                "t3.xlarge",
+                "t3.2xlarge",
                 "m4.large",
                 "m4.xlarge",
                 "m4.2xlarge",
@@ -118,6 +121,11 @@
                 "c5.4xlarge",
                 "r5.large",
                 "r5.xlarge",
+                "r5.2xlarge",
+                "r5.4xlarge",
+                "r5d.xlarge",
+                "r5d.2xlarge",
+                "r5d.4xlarge",
                 "r4.large",
                 "r4.xlarge",
                 "m5a.large",
@@ -126,7 +134,9 @@
                 "r5a.large",
                 "r5a.xlarge",
                 "i3.large",
-                "i3.xlarge"
+                "i3.xlarge",
+                "c5n.2xlarge",
+                "c5n.4xlarge"
             ]
         },
         "CouchbaseClusterUrl": {


### PR DESCRIPTION
    * Added t3.2xlarge, t3.xlarge, t3.large, r5.2xlarge, r5.4xlarge, r5d.xlarge, r5d.2xlarge, r5d.4xlarge, c5n.2xlarge, c5n.4xlarge instance types