### PR TITLE
MB-54983 - MDS For GCP

### DIFF
--- a/.github/workflows/GCP-CouchbaseServerDeploymentTests.yml
+++ b/.github/workflows/GCP-CouchbaseServerDeploymentTests.yml
@@ -112,7 +112,7 @@ jobs:
         run: echo "$GITHUB_WORKSPACE"
       # Runs a set of commands using the runners shell
       - name: Deploy To GCP
-        timeout-minutes: 15
+        timeout-minutes: 30
         run: bash ${GITHUB_WORKSPACE}/gcp/couchbase-server/mds_deploy.sh -n cb-server-mds
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1


### PR DESCRIPTION
  * Timeout needs to be longer as we are doing two deployments and not just one.