### PR TITLE
MB-54983 - MDS for GCP

### DIFF
--- a/gcp/couchbase-server/deploy.sh
+++ b/gcp/couchbase-server/deploy.sh
@@ -12,6 +12,8 @@ do
         *) exit 1;;
     esac
 done
+YQ_COMMAND=".resources[0].properties.name = \"$STACK_NAME\""
+yq -i "$YQ_COMMAND" "$SCRIPT_SOURCE/test_config.local.yaml"
 
 if [[ "$BYOL" == "0" ]]; then
     bash "${SCRIPT_SOURCE}/makeArchives.sh" "-n" "-l"

--- a/gcp/couchbase-server/mds_deploy.sh
+++ b/gcp/couchbase-server/mds_deploy.sh
@@ -14,7 +14,6 @@ CREATE_STACK_NAME="${STACK_NAME}-create"
 JOIN_STACK_NAME="${STACK_NAME}-join"
 
 # Step one is perform a deployment to create and read in the runtime config
-
 $SCRIPT_SOURCE/deploy.sh -b -n "$CREATE_STACK_NAME"
 
 JOIN_IP=$($SCRIPT_SOURCE/ip_retrieval.sh -n "$CREATE_STACK_NAME")


### PR DESCRIPTION
  * Because runtimeConfigName was generated from time and name property and multiple deploys were occurring in testing at the same time, we're making sure the name matches the deployment name.